### PR TITLE
Fix go 1.24.0 and not 1.24.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Scalingo/go-philae/v5
 
-go 1.24.3
+go 1.24.0
 
 require (
 	github.com/Scalingo/go-utils/logger v1.9.1


### PR DESCRIPTION
Fix version to `1.24.0` and not `1.24.3`. We cannot set it to `1.24` because [this](https://github.com/fsouza/go-dockerclient) dependency is explicitly setting to `1.24.0`.
Nonetheless I think it can be good to fix an earlier version, as it is more the "equivalent" of `1.24`.