### PR TITLE
Ensure response body from Elasticsearch info is properly closed

### DIFF
--- a/elasticsearchprobe/elasticsearchprobe.go
+++ b/elasticsearchprobe/elasticsearchprobe.go
@@ -68,7 +68,7 @@ func (p ElasticsearchProbe) Name() string {
 
 func (p *ElasticsearchProbe) createClient() (*opensearch.Client, error) {
 	var certPool *x509.CertPool
-	if p.caCert != nil && len(p.caCert) != 0 {
+	if len(p.caCert) != 0 {
 		certPool = p.certPool.FromCustomCA(p.caCert)
 	} else {
 		var err error
@@ -99,7 +99,10 @@ func (p *ElasticsearchProbe) Check(_ context.Context) error {
 		return errors.Wrap(p.clientErr, "fail to open a new connection to Elasticsearch")
 	}
 
-	_, err := p.client.Info()
+	resp, err := p.client.Info()
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return errors.Wrap(err, "fail to get elasticsearch info")
 	}

--- a/elasticsearchprobe/elasticsearchprobe_test.go
+++ b/elasticsearchprobe/elasticsearchprobe_test.go
@@ -16,6 +16,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
 func TestElasticsearchProbe_Check(t *testing.T) {
 	ctx := context.Background()
 
@@ -74,8 +78,6 @@ func TestElasticsearchProbe_Check(t *testing.T) {
 	})
 
 	t.Run("It should close the info body", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
-
 		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"version":{"distribution":"opensearch","number":"X.Y.Z"}}`))

--- a/elasticsearchprobe/elasticsearchprobe_test.go
+++ b/elasticsearchprobe/elasticsearchprobe_test.go
@@ -83,7 +83,7 @@ func TestElasticsearchProbe_Check(t *testing.T) {
 		defer serv.Close()
 
 		probe := NewElasticsearchProbe("test", serv.URL)
-		err := probe.Check(context.Background())
+		err := probe.Check(t.Context())
 		require.NoError(t, err)
 	})
 

--- a/elasticsearchprobe/elasticsearchprobe_test.go
+++ b/elasticsearchprobe/elasticsearchprobe_test.go
@@ -2,11 +2,13 @@ package elasticsearchprobe
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/opensearch-project/opensearch-go"
 
 	"github.com/Scalingo/go-philae/v5/elasticsearchprobe/elasticsearchprobemock"
 	"github.com/Scalingo/go-philae/v5/internal/tests"
@@ -14,6 +16,28 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type trackingTransport struct {
+	closed bool
+}
+
+func (t *trackingTransport) Read(_ []byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (t *trackingTransport) Close() error {
+	t.closed = true
+	return nil
+}
+
+func (t *trackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       t,
+		Request:    req,
+	}, nil
+}
 
 func TestElasticsearchProbe_Check(t *testing.T) {
 	ctx := context.Background()
@@ -70,5 +94,21 @@ func TestElasticsearchProbe_Check(t *testing.T) {
 			err := probe.Check(ctx)
 			require.NoError(t, err)
 		})
+	})
+
+	t.Run("It should close the info response body", func(t *testing.T) {
+		transport := &trackingTransport{}
+		client, err := opensearch.NewClient(opensearch.Config{
+			Addresses:            []string{"http://example.com"},
+			UseResponseCheckOnly: true,
+			Transport:            transport,
+		})
+		require.NoError(t, err)
+
+		probe := &ElasticsearchProbe{client: client}
+
+		err = probe.Check(ctx)
+		require.NoError(t, err)
+		require.True(t, transport.closed)
 	})
 }

--- a/elasticsearchprobe/elasticsearchprobe_test.go
+++ b/elasticsearchprobe/elasticsearchprobe_test.go
@@ -2,13 +2,12 @@ package elasticsearchprobe
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/opensearch-project/opensearch-go"
+	"go.uber.org/goleak"
 
 	"github.com/Scalingo/go-philae/v5/elasticsearchprobe/elasticsearchprobemock"
 	"github.com/Scalingo/go-philae/v5/internal/tests"
@@ -16,28 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type trackingTransport struct {
-	closed bool
-}
-
-func (t *trackingTransport) Read(_ []byte) (int, error) {
-	return 0, io.EOF
-}
-
-func (t *trackingTransport) Close() error {
-	t.closed = true
-	return nil
-}
-
-func (t *trackingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Header:     make(http.Header),
-		Body:       t,
-		Request:    req,
-	}, nil
-}
 
 func TestElasticsearchProbe_Check(t *testing.T) {
 	ctx := context.Background()
@@ -96,19 +73,18 @@ func TestElasticsearchProbe_Check(t *testing.T) {
 		})
 	})
 
-	t.Run("It should close the info response body", func(t *testing.T) {
-		transport := &trackingTransport{}
-		client, err := opensearch.NewClient(opensearch.Config{
-			Addresses:            []string{"http://example.com"},
-			UseResponseCheckOnly: true,
-			Transport:            transport,
-		})
-		require.NoError(t, err)
+	t.Run("It should close the info body", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
 
-		probe := &ElasticsearchProbe{client: client}
+		serv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"version":{"distribution":"opensearch","number":"X.Y.Z"}}`))
+		}))
+		defer serv.Close()
 
-		err = probe.Check(ctx)
+		probe := NewElasticsearchProbe("test", serv.URL)
+		err := probe.Check(context.Background())
 		require.NoError(t, err)
-		require.True(t, transport.closed)
 	})
+
 }

--- a/prober/prober_test.go
+++ b/prober/prober_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/Scalingo/go-philae/v5/sampleprobe"
 )
 
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
 func TestProber(t *testing.T) {
 	ctx := context.Background()
 	t.Run("With healthy probes", func(t *testing.T) {
@@ -89,8 +93,6 @@ func TestProber(t *testing.T) {
 	})
 
 	t.Run("With a single probe timeout no goroutines leak", func(t *testing.T) {
-		defer goleak.VerifyNone(t)
-
 		p := NewProber(WithTimeout(200 * time.Millisecond))
 		p.AddProbe(sampleprobe.NewTimedSampleProbe("test", true, 300*time.Millisecond))
 


### PR DESCRIPTION
Issue linked https://github.com/Scalingo/go-philae/issues/224 (linked in development part)
Created from pprof analysis done in https://github.com/Scalingo/mco-monitoring-service/issues/152#issuecomment-4878213078